### PR TITLE
Fix syntax error in functions.sh

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -258,7 +258,7 @@ if [ ! -f ${flashromcmd} ]; then
         cd /tmp/boot/util
     fi
 
-    if if [[ "$isChromeOS" = true ]]; then
+    if [[ "$isChromeOS" = true ]]; then
         #needed to avoid dependencies not found on older ChromeOS
         curl -sLO "${util_source}flashrom_old.tar.gz"
     else

--- a/functions.sh
+++ b/functions.sh
@@ -258,7 +258,12 @@ if [ ! -f ${flashromcmd} ]; then
         cd /tmp/boot/util
     fi
 
-    curl -sLO "${util_source}flashrom.tar.gz"
+    if if [[ "$isChromeOS" = true ]]; then
+        #needed to avoid dependencies not found on older ChromeOS
+        curl -sLO "${util_source}flashrom_old.tar.gz"
+    else
+        curl -sLO "${util_source}flashrom.tar.gz"
+    fi
     if [ $? -ne 0 ]; then
         echo_red "Error downloading flashrom; cannot proceed."
         #restore working dir


### PR DESCRIPTION
I was receiving errors around if statement tokens.

```
Downloading supporting files...
./functions.sh: line 286: syntax error near unexpected token `fi'
./functions.sh: line 286: `fi'
./firmware-util.sh: line 53: prelim_setup: command not found
```

Which I believed were caused by the double if statement on line 261. After fixing this, my problems seem to be resolved.

Believe this was just introduced a few hours ago. Quite a stroke of luck considering the last time I ran this script was in 2019 :)