### PR TITLE
functions.sh: add HWID for LG Chromebook 11TC50Q/11TQ50Q

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -83,8 +83,8 @@ cml_boxes=('duffy' 'faffy' 'kaisa' 'noibat' 'puff' 'wyvern')
 cml_books=('akemi' 'dragonair' 'drallion' 'dratini' 'hatch' 'helios' 'jinlon' 'kindred' 'kled' 'kohaku' 'nightfury')
 cml=($(printf "%s " "${cml_boxes[@]}" "${cml_books[@]}"))
 zen2=('berknip' 'dirinboz' 'ezkinil' 'morphius' 'woomax')
-jsl=('blipper' 'boten' 'drawcia' 'drawlat' 'drawman' 'galith' 'gallop' 'galtic' 'lantis' \
-     'magpie' 'magolor' 'sasuke' 'storo' 'storo360')
+jsl=('blipper' 'boten' 'drawcia' 'drawlat' 'drawman' 'galith' 'gallop' 'galtic' 'kracko' \
+     'lantis' 'magpie' 'magolor' 'sasuke' 'storo' 'storo360')
 tgl=('copano' 'delbin' 'drobit' 'eldrid' 'elemi' 'lillipup' 'lindar' 'volta' 'voxel')
 
 UEFI_ROMS=($(printf "%s " "${hsw_boxes[@]}" "${hsw_books[@]}" "${bdw_boxes[@]}" \
@@ -581,6 +581,7 @@ case "${_hwid}" in
     KIP*)                   _x='BYT|HP Chromebook 11 G3/G4, 14 G4' ;;
     KLED*)                  _x='CML|Acer Chromebook Spin 713 (CP713-2W)' ;;
     KOHAKU*)                _x='CML|Samsung Galaxy Chromebook' ;;
+    KRACKO360*)             _x='JSL|LG Chromebook 11TC50Q/11TQ50Q' ;;
     LANTIS-MEXL*)           _x='JSL|HP Chromebook 14a' ;;
     LARS_???-???-???-?3?*)  _x='SKL|Acer Chromebook 11 (C771, C771T)' ;;
     LARS*)                  _x='SKL|Acer Chromebook 14 for Work' ;;


### PR DESCRIPTION
This PR adds support for LG Chromebook 11TC50Q/11TQ50Q.

I tested this code on 11TC50Q.