### PR TITLE
LILLIPUP spelling mistake

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -621,7 +621,7 @@ case "${_hwid}" in
     LIBREM_MINI)            _x='WHL|Purism Librem Mini' ; device="librem_mini";;
     LIBREM_MINI_V2)         _x='CML|Purism Librem Mini v2' ; device="librem_mini_v2";;
     LICK*)                  _x='GLK|Lenovo Ideapad 3 Chromebook' ;;
-    LILIPUP*)               _x='TGL|Lenovo IdeaPad Flex 5i Chromebook' ;;
+    LILLIPUP*)              _x='TGL|Lenovo IdeaPad Flex 5i Chromebook' ;;
 	LINDAR-EDFZ*)           _x='TGL|Lenovo 5i-14 Chromebook' ;;
 	LINDAR-LCDF*)           _x='TGL|Lenovo Slim 5 Chromebook' ;;
     LINK*)                  _x='IVB|Google Chromebook Pixel 2013' ;;


### PR DESCRIPTION
Corrects a small typo which should also be corrected at https://wiki.mrchromebox.tech/Supported_Devices

As a reference: https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices/#:~:text=Flex%205i%20Chromebook-,lillipup,-volteer