### PR TITLE
add partition slection when backing up the original firmware

### DIFF
--- a/firmware.sh
+++ b/firmware.sh
@@ -639,13 +639,31 @@ if [[ "$REPLY" = "y" || "$REPLY" = "Y" ]]; then
 Connect the USB/SD device which contains the backed-up stock firmware and press [Enter] to continue. "
 	list_usb_devices
 	[ $? -eq 0 ] || { exit_red "No USB devices available to read firmware backup."; return 1; }
-	read -ep "Enter the number for the device which contains the stock firmware backup: " usb_dev_index
+	read -ep "Enter the number for the device: " usb_dev_index
 	[ $usb_dev_index -gt 0 ] && [ $usb_dev_index  -le $num_usb_devs ] || { exit_red "Error: Invalid option selected."; return 1; }
 	usb_device="${usb_devs[${usb_dev_index}-1]}"
+	for i in $usb_device*;
+	do
+		num_usb_partitions=$((num_usb_partitions+1));
+	done;
+	num_usb_partitions=$((num_usb_partitions-1));
 	mkdir /tmp/usb > /dev/null 2>&1
 	mount "${usb_device}" /tmp/usb > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
-		mount "${usb_device}1" /tmp/usb
+		num_usb_partition=1  
+		for i in $usb_device*; 
+		do 
+		if [[ ${i} =~ [0-9]+$ ]]; 
+		then 
+			echo -n "Partition ${num_usb_partition} size: ";
+			lsblk --noheadings -l -o SIZE $usb_device|tail -n $num_usb_partitions|sed -n ${num_usb_partition}p;
+			echo "";
+			num_usb_partition=$((num_usb_partition+1));
+		fi; 
+		done
+		read -ep "Enter the number for the device partition which contains the stock firmware backup: " usb_dev_partition_index
+		[ $usb_dev_partition_index -gt 0 ] && [ $usb_dev_partition_index  -le $num_usb_partition ] || { exit_red "Error: Invalid option selected."; return 1; }
+		mount "${usb_device}${usb_dev_partition_index}" /tmp/usb
 	fi
 	if [ $? -ne 0 ]; then
 		echo_red "USB device failed to mount; cannot proceed."

--- a/firmware.sh
+++ b/firmware.sh
@@ -639,7 +639,7 @@ if [[ "$REPLY" = "y" || "$REPLY" = "Y" ]]; then
 Connect the USB/SD device which contains the backed-up stock firmware and press [Enter] to continue. "
 	list_usb_devices
 	[ $? -eq 0 ] || { exit_red "No USB devices available to read firmware backup."; return 1; }
-	read -ep "Enter the number for the device: " usb_dev_index
+	read -ep "Enter the number for the device which contains the stock firmware backup: " usb_dev_index
 	[ $usb_dev_index -gt 0 ] && [ $usb_dev_index  -le $num_usb_devs ] || { exit_red "Error: Invalid option selected."; return 1; }
 	usb_device="${usb_devs[${usb_dev_index}-1]}"
 	mkdir /tmp/usb > /dev/null 2>&1
@@ -1557,6 +1557,6 @@ function partition_selection() {
 		num_usb_partition=$((num_usb_partition+1));
 	fi; 
 	done
-	read -ep "Enter the number for the device partition which contains the stock firmware backup: " usb_dev_partition_index
+	read -ep "Enter the number for the device partition in the USB drive: " usb_dev_partition_index
 	return $usb_dev_partition_index
 }

--- a/firmware.sh
+++ b/firmware.sh
@@ -1551,7 +1551,7 @@ function partition_selection() {
 	do 
 	if [[ ${i} =~ [0-9]+$ ]]; 
 	then 
-		echo -n "Partition ${num_usb_partition} size: ";
+		echo -n "Partition ${BASH_REMATCH[0]} size: ";
 		lsblk --noheadings -l -o SIZE $1|tail -n $num_usb_partitions|sed -n ${num_usb_partition}p;
 		echo "";
 		num_usb_partition=$((num_usb_partition+1));

--- a/firmware.sh
+++ b/firmware.sh
@@ -655,7 +655,7 @@ Connect the USB/SD device which contains the backed-up stock firmware and press 
 		do 
 		if [[ ${i} =~ [0-9]+$ ]]; 
 		then 
-			echo -n "Partition ${num_usb_partition} size: ";
+			echo -n "Partition ${i: -1} size: ";
 			lsblk --noheadings -l -o SIZE $usb_device|tail -n $num_usb_partitions|sed -n ${num_usb_partition}p;
 			echo "";
 			num_usb_partition=$((num_usb_partition+1));


### PR DESCRIPTION
The current script backups up the firmware to the first partition in the USB drive by default. This commit will support back up the original firmware to the custom partition. I also found that when the USB drive has uneven partitions, the baking up process will be failure. For example, if  /dev/sdc only have a partition named /dev/sdc4, the backing up process will be failure. This commit will fix it.