### PR TITLE
Allow -n for off-line operation, running from a mounted USB

### DIFF
--- a/firmware-util.sh
+++ b/firmware-util.sh
@@ -39,9 +39,7 @@ fi
 
 #get support scripts
 echo -e "\nDownloading supporting files..."
-rm -rf firmware.sh >/dev/null 2>&1
-rm -rf functions.sh >/dev/null 2>&1
-rm -rf sources.sh >/dev/null 2>&1
+rm -rf firmware.sh functions.sh sources.sh >/dev/null 2>&1
 $CURL -sLO ${script_url}firmware.sh
 rc0=$?
 $CURL -sLO ${script_url}functions.sh

--- a/functions.sh
+++ b/functions.sh
@@ -188,6 +188,25 @@ function list_usb_devices()
 	return 0
 }
 
+##########################################
+# Mount the found USB device on /tmp/usb #
+##########################################
+function mount_usb_device()
+{
+	usb_dev_index=""
+	while [[ "$usb_dev_index" = "" || ($usb_dev_index -le 0 && $usb_dev_index -gt $num_usb_devs) ]]; do
+		read -rep "Enter the number for the device to be used for firmware backup: " usb_dev_index
+		if [[ "$usb_dev_index" = "" || ($usb_dev_index -le 0 && $usb_dev_index -gt $num_usb_devs) ]]; then
+			echo -e "Error: Invalid option selected; enter a number from the list above."
+		fi
+	done
+
+	usb_device="${usb_devs[${usb_dev_index}-1]}"
+	mkdir /tmp/usb > /dev/null 2>&1
+	mount "${usb_device}" /tmp/usb > /dev/null 2>&1 ||
+		mount "${usb_device}1" /tmp/usb > /dev/null 2>&1
+}
+
 
 ################
 # Get cbfstool #

--- a/functions.sh
+++ b/functions.sh
@@ -204,7 +204,8 @@ function mount_usb_device()
 	usb_device="${usb_devs[${usb_dev_index}-1]}"
 	mkdir /tmp/usb > /dev/null 2>&1
 	mount "${usb_device}" /tmp/usb > /dev/null 2>&1 ||
-		mount "${usb_device}1" /tmp/usb > /dev/null 2>&1
+		mount "${usb_device}1" /tmp/usb > /dev/null 2>&1 ||
+		{ mounted="$(df -x devtmpfs "${usb_device}" || df -x devtmpfs "${usb_device}1")" 2>/dev/null && mount --bind "${mounted}" /tmp/usb > /dev/null 2>&1; }
 }
 
 


### PR DESCRIPTION
This allows downloading `firmware-util.sh`, running it from a USB stick (incl. firmware backups which previously wanted to exclusively mount and unmount it), and by passing `-n` the file in the same directory with the same basename will be used, and the URL logged to the screen and to `curls` (in a format that can be passed to `sh curls`), which allows, with a few round-trips, correct operation without connecting the chromebook to wi-fi or clicking through the OOBE at all.