### PR TITLE
Add "WSL is not supported"

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -337,7 +337,7 @@ device=$(dmidecode -s system-product-name | tr '[:upper:]' '[:lower:]' | sed 's/
 if [[ $? -ne 0 || "${device}" = "" ]]; then
 	echo_red "Unable to determine Chromebox/book model; cannot continue."
 	echo_red "It's likely you are using an unsupported ARM-based ChromeOS device,\nonly Intel-based devices are supported at this time."
-        echo_red "Please note that WSL (Windows Subsystem for Linux) is not supported at the moment, and probably won't be.
+        echo_red "Please note that WSL (Windows Subsystem for Linux) is not supported and NEVER will. Run this from a Linux Live USB instead."
 	return 1
 fi
 

--- a/functions.sh
+++ b/functions.sh
@@ -337,6 +337,7 @@ device=$(dmidecode -s system-product-name | tr '[:upper:]' '[:lower:]' | sed 's/
 if [[ $? -ne 0 || "${device}" = "" ]]; then
 	echo_red "Unable to determine Chromebox/book model; cannot continue."
 	echo_red "It's likely you are using an unsupported ARM-based ChromeOS device,\nonly Intel-based devices are supported at this time."
+        echo_red "Please note that WSL (Windows Subsystem for Linux) is not supported at the moment, and probably won't be.
 	return 1
 fi
 


### PR DESCRIPTION
Before this, if WSL was being used the error would be given without being told WSL doesn't work properly with the util (Thats what common sense is for however, some of us dont have it)

This is a simple fix, maybe later I can upgrade it even more.