### PR TITLE
Save the user's time by detecting WSL at script start

### DIFF
--- a/firmware-util.sh
+++ b/firmware-util.sh
@@ -32,7 +32,9 @@ echo -e "\nMrChromebox Firmware Utility Script starting up"
 
 # check for unsupported kernel (WSL)
 if [[ $(grep -i Microsoft /proc/version) ]]; then
-echo "You are running this script on WSL, which is NOT supported and never will be."
+echo "
+
+You are running this script on WSL, which is NOT supported and never will be."
 echo "Please create a Linux Live USB and run this script from there."
 echo "If this is a false positive, please manually delete this detection from the file."
 exit 1

--- a/firmware-util.sh
+++ b/firmware-util.sh
@@ -31,11 +31,11 @@ printf "\ec"
 echo -e "\nMrChromebox Firmware Utility Script starting up"
 
 # check for unsupported kernel (WSL)
-kernel=$(uname -r)
-if [[ $kernel == *"WSL"* ]]; then
-  echo_red "You are using an unsupported kernel (WSL). WSL is currently not supported and NEVER will. Boot from a Live Linux USB and run this script from there."
-  echo_red "If this seems to be in error, make a issue request on MrChromeboxes scripts repository."
-  exit 1
+if [[ $(grep -i Microsoft /proc/version) ]]; then
+echo_red "You are running this script on WSL, which is NOT supported and never will be."
+echo_red "Please create a Linux Live USB and run this script from there."
+echo_red "If this is a false positive, please manually delete this detection from the file."
+exit 1
 fi
 
 #check for cmd line param, expired CrOS certs

--- a/firmware-util.sh
+++ b/firmware-util.sh
@@ -31,8 +31,8 @@ printf "\ec"
 echo -e "\nMrChromebox Firmware Utility Script starting up"
 
 # check for unsupported kernel (WSL)
-string="uname -r"
-if [[ $string == *"WSL"* ]]; then
+kernel=$(uname -r)
+if [[ $kernel == *"WSL"* ]]; then
   echo_red "You are using an unsupported kernel (WSL). WSL is currently not supported and NEVER will. Boot from a Live Linux USB and run this script from there."
   echo_red "If this seems to be in error, make a issue request on MrChromeboxes scripts repository."
   exit 1

--- a/firmware-util.sh
+++ b/firmware-util.sh
@@ -31,7 +31,7 @@ printf "\ec"
 echo -e "\nMrChromebox Firmware Utility Script starting up"
 
 # check for unsupported kernel (WSL)
-string=uname -r
+string="uname -r"
 if [[ $string == *"WSL"* ]]; then
   echo_red "You are using an unsupported kernel (WSL). WSL is currently not supported and NEVER will. Boot from a Live Linux USB and run this script from there."
   echo_red "If this seems to be in error, make a issue request on MrChromeboxes scripts repository."

--- a/firmware-util.sh
+++ b/firmware-util.sh
@@ -32,9 +32,9 @@ echo -e "\nMrChromebox Firmware Utility Script starting up"
 
 # check for unsupported kernel (WSL)
 if [[ $(grep -i Microsoft /proc/version) ]]; then
-echo_red "You are running this script on WSL, which is NOT supported and never will be."
-echo_red "Please create a Linux Live USB and run this script from there."
-echo_red "If this is a false positive, please manually delete this detection from the file."
+echo "You are running this script on WSL, which is NOT supported and never will be."
+echo "Please create a Linux Live USB and run this script from there."
+echo "If this is a false positive, please manually delete this detection from the file."
 exit 1
 fi
 

--- a/firmware-util.sh
+++ b/firmware-util.sh
@@ -30,6 +30,14 @@ fi
 printf "\ec"
 echo -e "\nMrChromebox Firmware Utility Script starting up"
 
+# check for unsupported kernel (WSL)
+string=uname -r
+if [[ $string == *"WSL"* ]]; then
+  echo_red "You are using an unsupported kernel (WSL). WSL is currently not supported and NEVER will. Boot from a Live Linux USB and run this script from there."
+  echo_red "If this seems to be in error, make a issue request on MrChromeboxes scripts repository."
+  exit 1
+fi
+
 #check for cmd line param, expired CrOS certs
 if ! curl -sLo /dev/null https://mrchromebox.tech/index.html || [[ "$1" = "-k" ]]; then
 	export CURL="curl -k"

--- a/functions.sh
+++ b/functions.sh
@@ -337,7 +337,7 @@ device=$(dmidecode -s system-product-name | tr '[:upper:]' '[:lower:]' | sed 's/
 if [[ $? -ne 0 || "${device}" = "" ]]; then
 	echo_red "Unable to determine Chromebox/book model; cannot continue."
 	echo_red "It's likely you are using an unsupported ARM-based ChromeOS device,\nonly Intel-based devices are supported at this time."
-        echo_red "Please note that WSL (Windows Subsystem for Linux) is not supported at the moment, and probably won't be.
+        echo_red "Please note that WSL (Windows Subsystem for Linux) is not supported and NEVER will. Run this from a Linux Live USB instead."
 	return 1
 fi
 

--- a/functions.sh
+++ b/functions.sh
@@ -337,6 +337,7 @@ device=$(dmidecode -s system-product-name | tr '[:upper:]' '[:lower:]' | sed 's/
 if [[ $? -ne 0 || "${device}" = "" ]]; then
 	echo_red "Unable to determine Chromebox/book model; cannot continue."
 	echo_red "It's likely you are using an unsupported ARM-based ChromeOS device,\nonly Intel-based devices are supported at this time."
+        echo_red "Please note that WSL (Windows Subsystem for Linux) is not supported at the moment, and probably won't be.
 	return 1
 fi
 


### PR DESCRIPTION
This is a further improvement on the "WSL is not supported" pull request,

This will detect the kernel version, and if it contains "Microsoft" the script will stop with an error telling the user that WSL doesn't work. The notice in functions.sh still exists, just in case someone using WSL deletes the detection.
This needs further testing on normal Linux distros.