### PR TITLE
Add pre-defined / Auto generated HWID's

### DIFF
--- a/database/cros-hwid.json
+++ b/database/cros-hwid.json
@@ -1,0 +1,233 @@
+{
+  "_meta": {
+    "schema": "codename_to_hwid_min.v1",
+    "updated": "2026-01-20",
+    "fields": {
+      "hwid": "string",
+      "owner_history": "enum: clean|unknown|suspected_bad|proven_bad",
+      "confidence_valid": "0.0-1.0",
+      "confidence_allegation": "0.0-1.0",
+      "notes": "short string (optional)"
+    }
+  },
+  "devices": {
+    "HANA": [
+      {
+        "hwid": "HANA L4A-D75-C2H-E2Q-P2U-B4Q",
+        "owner_history": "proven_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 1,
+        "notes": "Proven enrolled/linked to an organization"
+      },
+      {
+        "hwid": "HANA 14A-D7K-A2A-G2Q-B2W-A83",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.1,
+        "notes": "Suspected org enrollment"
+      },
+      {
+        "hwid": "HANA 14A-D7Z-A6E-A2I-D2E-B9K",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.1,
+        "notes": "Suspected org enrollment"
+      }
+    ],
+    "SHYVANA": [
+      {
+        "hwid": "SHYVANA C5B-A4G-C4Q-S24-A9U",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "JINLON-YTGY": [
+      {
+        "hwid": "JINLON-YTGY C5B-O5B-E4E-S3Q-E9L",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5,
+        "notes": "Unsure"
+      }
+    ],
+    "KIP": [
+      {
+        "hwid": "KIP C5A-G2O-H6A-A5V",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "EVE": [
+      {
+        "hwid": "EVE D6B-A6A-C4C-F8N-P8A-A37",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "GRABBITER": [
+      {
+        "hwid": "GRABBITER G7B-B4E-O57-L8M-E6T-Q8Q-A2K",
+        "owner_history": "unknown",
+        "confidence_valid": 0.5,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      },
+      {
+        "hwid": "GRABBITER D6B-B3C-C5P-M8I-C6Y-A72",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      },
+      {
+        "hwid": "GRABBITER G7C-B4C-O52-M4Y-C8T-Q8Q-A2M",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment"
+      }
+    ],
+    "NASHER": [
+      {
+        "hwid": "NASHER D5F-B4K-C47-W5K-S4C-I6A-A9A",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5,
+        "notes": "Unsure"
+      }
+    ],
+    "BARLA": [
+      {
+        "hwid": "BARLA C4B-A4L-F3V-M8G-I2Q-C2E-A8B",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "FLEEX": [
+      {
+        "hwid": "FLEEX D7B-B4D-G57-N8N-J4M-G2Q-A6D",
+        "owner_history": "proven_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 1,
+        "notes": "Proven enrolled/linked to an organization"
+      },
+      {
+        "hwid": "FLEEX D7B-B4B-H5V-N2B-A4M-H2M",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      },
+      {
+        "hwid": "FLEEX D6B-B3D-G5V-P3J-B4E-B7K",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      }
+    ],
+    "FALCO": [
+      {
+        "hwid": "FALCO C3J-C3I-P8N",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      },
+      {
+        "hwid": "FALCO C2A-U6Y-D95",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "BLOOGET": [
+      {
+        "hwid": "BLOOGET C2Q-A4D-D2K-T7X-U8A-A9N",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      }
+    ],
+    "GNAWTY": [
+      {
+        "hwid": "GNAWTY C2Q-E55-A5B",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "MINNIE": [
+      {
+        "hwid": "MINNIE F25-S2E-Q4G-A3C",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "NAUTILUS": [
+      {
+        "hwid": "NAUTILUS D5B-A2E-B5M-D97-Q34",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      }
+    ],
+    "AKALI360": [
+      {
+        "hwid": "AKALI360 C4B-A2C-F3K-65U-I8T",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      }
+    ],
+    "PEPPY": [
+      {
+        "hwid": "PEPPY C3A-B3E-A3D",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "BANJO": [
+      {
+        "hwid": "BANJO C7A-C2I-A65",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "LASER14": [
+      {
+        "hwid": "LASER14 C3J-A2E-A3K-I4Q-I4I",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      }
+    ],
+    "GANDOF": [
+      {
+        "hwid": "GANDOF D25-A4W-B3Q-A6E",
+        "owner_history": "unknown",
+        "confidence_valid": 1,
+        "confidence_allegation": 0.5
+      }
+    ],
+    "CAREENA": [
+      {
+        "hwid": "CAREENA C5B-A41-D4Q-A3Y-O6R-A2B-E9E",
+        "owner_history": "suspected_bad",
+        "confidence_valid": 0.8,
+        "confidence_allegation": 0.3,
+        "notes": "Suspected org enrollment; reason: owner's tpm BAD"
+      }
+    ]
+  }
+}

--- a/firmware.sh
+++ b/firmware.sh
@@ -1477,31 +1477,23 @@ function fixcraft_hwid_select_predefined() {
 
 	py_bin=$(fixcraft_find_python) || { echo_yellow "Python not found; skipping pre-defined IDs." >&2; return 3; }
 
-	lines=$("$py_bin" - "$db_file" "$board" <<'PY'
-import json
-import sys
-
+	lines=$("$py_bin" -c 'import json,sys
 if len(sys.argv) < 3:
     sys.exit(3)
-
 db_file = sys.argv[1]
 board = sys.argv[2]
-
 try:
     with open(db_file, "r", encoding="utf-8") as fh:
         data = json.load(fh)
 except Exception:
     sys.exit(3)
-
 entries = data.get("devices", {}).get(board, [])
 items = []
-
 def to_float(val, default):
     try:
         return float(val)
     except Exception:
         return default
-
 for entry in entries:
     if not isinstance(entry, dict):
         continue
@@ -1511,16 +1503,12 @@ for entry in entries:
     valid = to_float(entry.get("confidence_valid", 1.0), 1.0)
     allegation = to_float(entry.get("confidence_allegation", 1.0), 1.0)
     items.append((hwid, valid, allegation))
-
 if not items:
     sys.exit(1)
-
 best_idx = min(range(len(items)), key=lambda i: (items[i][2], -items[i][1], i))
 for i, (hwid, valid, allegation) in enumerate(items, 1):
     rec = 1 if (i - 1) == best_idx else 0
-    print(f"{i}|{hwid}|{valid}|{allegation}|{rec}")
-PY
-)
+    print(f\"{i}|{hwid}|{valid}|{allegation}|{rec}\")' "$db_file" "$board")
 	status=$?
 	if [[ $status -eq 1 ]]; then
 		return 1

--- a/firmware.sh
+++ b/firmware.sh
@@ -1716,6 +1716,11 @@ function fixcraft_hwid_manual() {
 	echo "${hwid}"
 }
 
+function fixcraft_hwid_disclaimer() {
+	echo_yellow "FixCraft, Inc. provides hardware IDs AS IS with no warranty." >&2
+	echo_yellow "Use at your own risk; no guarantees of fitness or support." >&2
+}
+
 function select_new_hwid() {
 	local current_hwid="$1"
 	local board=""
@@ -1751,6 +1756,7 @@ function select_new_hwid() {
 		if [[ -s "${db_file}" ]]; then
 			hwid=$(fixcraft_hwid_select_predefined "${db_file}" "${board}") || status=$?
 			if [[ -n "${hwid}" ]]; then
+				fixcraft_hwid_disclaimer
 				echo "${hwid}"
 				return 0
 			fi
@@ -1760,6 +1766,7 @@ function select_new_hwid() {
 			echo_yellow "looks like your device isnt in the FixCraft Database!" >&2
 			hwid=$(fixcraft_hwid_generate "${board}") || true
 			if [[ -n "${hwid}" ]]; then
+				fixcraft_hwid_disclaimer
 				echo "${hwid}"
 				return 0
 			fi
@@ -1771,6 +1778,7 @@ function select_new_hwid() {
 		if [[ "${confirm}" = "A" || "${confirm}" = "a" ]]; then
 			hwid=$(fixcraft_hwid_generate "${board}") || true
 			if [[ -n "${hwid}" ]]; then
+				fixcraft_hwid_disclaimer
 				echo "${hwid}"
 				return 0
 			fi

--- a/firmware.sh
+++ b/firmware.sh
@@ -1814,8 +1814,8 @@ function set_hwid()
 
 	echo_yellow "Are you sure you know what you're doing here?
 Changing this is not normally needed, and if you mess it up,
-MrChromebox is not going to help you fix it. This won't let
-you run a different/newer version of ChromeOS.
+MrChromebox is not going to help you fix it. 
+* This won't let you run a different/newer version of ChromeOS.
 Proceed at your own risk.
 P.S. using a pre-defined HWID may allow updates
 to work correctly."

--- a/firmware.sh
+++ b/firmware.sh
@@ -1508,7 +1508,7 @@ if not items:
 best_idx = min(range(len(items)), key=lambda i: (items[i][2], -items[i][1], i))
 for i, (hwid, valid, allegation) in enumerate(items, 1):
     rec = 1 if (i - 1) == best_idx else 0
-    print(f\"{i}|{hwid}|{valid}|{allegation}|{rec}\")' "$db_file" "$board")
+    print("{}|{}|{}|{}|{}".format(i, hwid, valid, allegation, rec))' "$db_file" "$board")
 	status=$?
 	if [[ $status -eq 1 ]]; then
 		return 1

--- a/firmware.sh
+++ b/firmware.sh
@@ -1461,8 +1461,8 @@ function fixcraft_hwid_lookup_predefined() {
 	local board="$2"
 
 	awk -v board="$board" '
-		$0 ~ "\"" board "\"[[:space:]]*:[[:space:]]*\\[" { in=1; next }
-		in && /"hwid"[[:space:]]*:/ {
+		$0 ~ "\"" board "\"[[:space:]]*:[[:space:]]*\\[" { in_block=1; next }
+		in_block && /"hwid"[[:space:]]*:/ {
 			match($0, /"hwid"[[:space:]]*:[[:space:]]*"[^"]+"/)
 			if (RSTART) {
 				hwid=substr($0, RSTART, RLENGTH)
@@ -1472,7 +1472,7 @@ function fixcraft_hwid_lookup_predefined() {
 				exit
 			}
 		}
-		in && /]/ { exit }
+		in_block && /]/ { exit }
 	' "${db_file}"
 }
 

--- a/firmware.sh
+++ b/firmware.sh
@@ -1477,7 +1477,7 @@ function fixcraft_hwid_select_predefined() {
 
 	py_bin=$(fixcraft_find_python) || { echo_yellow "Python not found; skipping pre-defined IDs." >&2; return 3; }
 
-	lines=$("$py_bin" - "$db_file" "$board" <<'PY')
+	lines=$("$py_bin" - "$db_file" "$board" <<'PY'
 import json
 import sys
 
@@ -1520,6 +1520,7 @@ for i, (hwid, valid, allegation) in enumerate(items, 1):
     rec = 1 if (i - 1) == best_idx else 0
     print(f"{i}|{hwid}|{valid}|{allegation}|{rec}")
 PY
+)
 	status=$?
 	if [[ $status -eq 1 ]]; then
 		return 1

--- a/generate-hwid.sh
+++ b/generate-hwid.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --board BOARD" >&2
+}
+
+board=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --board)
+      board=${2:-}
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$board" ]; then
+  usage
+  exit 1
+fi
+
+board=$(printf '%s' "$board" | tr '[:lower:]' '[:upper:]')
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+data_file="$script_dir/database/cros-hwid.json"
+
+node_bin=""
+if command -v node >/dev/null 2>&1; then
+  node_bin="node"
+elif command -v nodejs >/dev/null 2>&1; then
+  node_bin="nodejs"
+else
+  echo "Error: node (or nodejs) is required to run this script." >&2
+  exit 1
+fi
+
+"$node_bin" - <<'NODE' "$data_file" "$board"
+const fs = require("fs");
+const file = process.argv[2];
+const board = process.argv[3];
+if (!file || !board) {
+  console.error("Usage: generate-hwid.sh --board BOARD");
+  process.exit(1);
+}
+const data = JSON.parse(fs.readFileSync(file, "utf8"));
+const devices = data.devices || {};
+
+function randInt(n) {
+  return Math.floor(Math.random() * n);
+}
+
+function pick(arr) {
+  return arr[randInt(arr.length)];
+}
+
+function parseGroups(hwid) {
+  if (!hwid) return [];
+  const parts = String(hwid).split(" ");
+  if (parts.length < 2) return [];
+  return parts.slice(1).join(" ").split("-").filter(Boolean);
+}
+
+function flattenEntries(map) {
+  const all = [];
+  for (const entries of Object.values(map)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (entry && entry.hwid) all.push(entry);
+    }
+  }
+  return all;
+}
+
+function charPattern(group) {
+  let hexOnly = true;
+  const pattern = [];
+  for (const ch of group) {
+    if (ch >= "0" && ch <= "9") {
+      pattern.push("D");
+    } else if (ch >= "A" && ch <= "Z") {
+      pattern.push("A");
+    } else {
+      pattern.push("X");
+    }
+    if (!((ch >= "0" && ch <= "9") || (ch >= "A" && ch <= "F"))) {
+      hexOnly = false;
+    }
+  }
+  return { pattern: pattern.join(""), hexOnly };
+}
+
+function genChar(type, hexOnly) {
+  if (type === "D") {
+    return String(randInt(10));
+  }
+  if (type === "A") {
+    const letters = hexOnly ? "ABCDEF" : "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    return letters[randInt(letters.length)];
+  }
+  const pool = hexOnly
+    ? "0123456789ABCDEF"
+    : "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  return pool[randInt(pool.length)];
+}
+
+function genGroupFromTemplate(group) {
+  const { pattern, hexOnly } = charPattern(group);
+  if (!pattern) return "";
+  let out = "";
+  for (const t of pattern) {
+    out += genChar(t, hexOnly);
+  }
+  return out;
+}
+
+const entries = devices[board];
+let pool = entries;
+if (!Array.isArray(pool) || pool.length === 0) {
+  console.error("Board unsupported, trying random");
+  pool = flattenEntries(devices);
+}
+
+let groups = [];
+if (pool.length > 0) {
+  const template = pick(pool);
+  groups = parseGroups(template.hwid);
+}
+
+const groupCount = groups.length || 4;
+const prefixLen = Math.min(2, groupCount);
+const outGroups = [];
+
+for (let i = 0; i < groupCount; i++) {
+  if (i < prefixLen && groups[i]) {
+    outGroups.push(groups[i]);
+    continue;
+  }
+  const templateGroup = groups[i] || "A0Z";
+  outGroups.push(genGroupFromTemplate(templateGroup));
+}
+
+console.log(`${board} ${outGroups.join("-")}`);
+NODE


### PR DESCRIPTION
this update will allow users to use a pre defined HWID, which are hardware id's of devices that exist and are valid, this WILL allow updates to work properly (tested on FLEEX chromebook dell 3100 (octopus))
however, user can also try generating an HWID, which has a not so high success rate of generating a 100% valid HWID, but might work.

users now need to type "I KNOW WHAT IM DOING" if they want to manually enter an HWID